### PR TITLE
Remove virtualenv requirement for system level pip

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -107,7 +107,6 @@ if [ -d ~/.virtualenvs ]; then
   export WORKON_HOME=$HOME/.virtualenvs
   export PIP_VIRTUALENV_BASE=$WORKON_HOME
   export VIRTUALENV_USE_DISTRIBUTE=true
-  export PIP_REQUIRE_VIRTUALENV=true
   export PIP_DOWNLOAD_CACHE=$HOME/.pip/cache
   [[ -f /opt/local/bin/virtualenvwrapper.sh ]] && . /opt/local/bin/virtualenvwrapper.sh
 fi


### PR DESCRIPTION
It's too restrictive to not allow pip to install anything at the system level unless there's an active virtualenv. Since system level Python site-package installs require `sudo` anyway, that's enough of a reminder.
